### PR TITLE
Localize text in content dashboard

### DIFF
--- a/TheDashboard/TheDashboard.csproj
+++ b/TheDashboard/TheDashboard.csproj
@@ -19,6 +19,7 @@
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
+    <UseGlobalApplicationHostFile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -201,6 +202,9 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-UK.xml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\es-ES.xml">
       <SubType>Designer</SubType>
     </Content>
     <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-US.xml">

--- a/TheDashboard/TheDashboard.csproj
+++ b/TheDashboard/TheDashboard.csproj
@@ -201,9 +201,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-UK.xml">
-      <SubType>Designer</SubType>
-    </Content>
+    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-GB.xml" />
     <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\es-ES.xml">
       <SubType>Designer</SubType>
     </Content>

--- a/TheDashboard/TheDashboard.csproj
+++ b/TheDashboard/TheDashboard.csproj
@@ -200,6 +200,15 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-UK.xml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\en-US.xml">
+      <SubType>Designer</SubType>
+    </Content>
+    <Content Include="Web\UI\App_Plugins\TheDashboard\Lang\da-DK.xml">
+      <SubType>Designer</SubType>
+    </Content>
     <Content Include="Web\UI\App_Plugins\TheDashboard\TheDevDashboard.controller.js" />
     <Content Include="Web\UI\App_Plugins\TheDashboard\TheDashboard.controller.js" />
     <Content Include="Web\UI\App_Plugins\TheDashboard\TheDashboard.css" />

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/da-DK.xml
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/da-DK.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+    <area alias="theDashboard">
+        <key alias="recentActivities">Senest aktiviteter</key>
+        <key alias="recentActivitiesDescription">Viser senest aktiviteter for alle brugere i bagkontoret.</key>
+        <key alias="unpublishedContent">Ikke-udgivet indhold</key>
+        <key alias="unpublishedContentDescription">Viser ikke-udgivet indhold som ikke er sat til udgivelse.</key>
+        <key alias="yourRecentActivity">Din seneste aktivitet</key>
+        <key alias="yourRecentActivitiesDescription">Viser dine seneste aktiviteter</key>
+        <key alias="publishedContentNodes">Udgivet indholdsnoder</key>
+        <key alias="nodesInRecycleBin">Noder i papirkurv</key>
+        <key alias="membersOnWebsite">Medlemmer på website</key>
+        <key alias="newMembersLastWeek">Nye medlemmer seneste uge</key>
+        <key alias="butNotPublishedOrScheduled">men ikke udgivet eller planlagt</key>
+        <key alias="butDidNotPublish">men ikke udgivet</key>
+        <key alias="forPublishingAt">til udgivelse fra</key>
+        <key alias="to">til</key>
+        <key alias="saved">gemt</key>
+        <key alias="moved">flyttet</key>
+        <key alias="unpublished">ikke-udgivet</key>
+        <key alias="savedBy">gemt af</key>
+        <key alias="savedAndScheduled">gemt og planlagt</key>
+        <key alias="savedAndPublished">gemt og udgivet</key>
+        <key alias="recycleBin">papirkurv</key>
+        <key alias="Saved">Gemt</key>
+        <key alias="Moved">Flyttet</key>
+        <key alias="Unpublished">Fjernet fra udgivelse</key>
+        <key alias="SavedAndScheduled">Gemt og planlagt</key>
+        <key alias="SavedAndPublished">Gemt og udgivet</key>
+    </area>
+</language>

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/en-GB.xml
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/en-GB.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+    <area alias="theDashboard">
+      <key alias="recentActivities">Recent activities</key>
+      <key alias="recentActivitiesDescription">Shows recent activites from all users in the back office.</key>
+      <key alias="unpublishedContent">Unpublished content</key>
+      <key alias="unpublishedContentDescription">Shows unpublished content that has not been been scheduled for publish.</key>
+      <key alias="yourRecentActivity">Your recent activity</key>
+      <key alias="yourRecentActivitiesDescription">Shows your own recent activities</key>
+      <key alias="publishedContentNodes">Published content nodes</key>
+      <key alias="nodesInRecycleBin">Nodes in recyle bin</key>
+      <key alias="membersOnWebsite">Members on website</key>
+      <key alias="newMembersLastWeek">New members last week</key>
+      <key alias="butNotPublishedOrScheduled">but not published or scheduled</key>
+      <key alias="butDidNotPublish">but did not publish</key>
+      <key alias="forPublishingAt">for publishing at</key>
+      <key alias="to">to</key>
+      <key alias="saved">saved</key>
+      <key alias="moved">moved</key>
+      <key alias="unpublished">unpublished</key>
+      <key alias="savedBy">saved by</key>
+      <key alias="savedAndScheduled">saved and scheduled</key>
+      <key alias="savedAndPublished">saved and published</key>
+      <key alias="recycleBin">recycle bin</key>
+      <key alias="Saved">Saved</key>
+      <key alias="Moved">Moved</key>
+      <key alias="Unpublished">Unpublished</key>
+      <key alias="SavedAndScheduled">Saved and scheduled</key>
+      <key alias="SavedAndPublished">Saved and published</key>
+    </area>
+</language>

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/en-US.xml
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/en-US.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+    <area alias="theDashboard">
+        <key alias="recentActivities">Recent activities</key>
+        <key alias="recentActivitiesDescription">Shows recent activites from all users in the back office.</key>
+        <key alias="unpublishedContent">Unpublished content</key>
+        <key alias="unpublishedContentDescription">Shows unpublished content that has not been been scheduled for publish.</key>
+        <key alias="yourRecentActivity">Your recent activity</key>
+        <key alias="yourRecentActivitiesDescription">Shows your own recent activities</key>
+        <key alias="publishedContentNodes">Published content nodes</key>
+        <key alias="nodesInRecycleBin">Nodes in recyle bin</key>
+        <key alias="membersOnWebsite">Members on website</key>
+        <key alias="newMembersLastWeek">New members last week</key>
+        <key alias="butNotPublishedOrScheduled">but not published or scheduled</key>
+        <key alias="butDidNotPublish">but did not publish</key>
+        <key alias="forPublishingAt">for publishing at</key>
+        <key alias="to">to</key>
+        <key alias="saved">saved</key>
+        <key alias="moved">moved</key>
+        <key alias="unpublished">unpublished</key>
+        <key alias="savedBy">saved by</key>
+        <key alias="savedAndScheduled">saved and scheduled</key>
+        <key alias="savedAndPublished">saved and published</key>
+        <key alias="recycleBin">recycle bin</key>
+        <key alias="Saved">Saved</key>
+        <key alias="Moved">Moved</key>
+        <key alias="Unpublished">Unpublished</key>
+        <key alias="SavedAndScheduled">Saved and scheduled</key>
+        <key alias="SavedAndPublished">Saved and published</key>
+    </area>
+</language>

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/es-ES.xml
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/Lang/es-ES.xml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<language>
+    <area alias="theDashboard">
+        <key alias="recentActivities">Actividad reciente</key>
+        <key alias="recentActivitiesDescription">Muestra la actividad reciente de todos los usuarios en la administración.</key>
+        <key alias="unpublishedContent">Contenido no publicado</key>
+        <key alias="unpublishedContentDescription">Muestra el contenido no publicado que no está programado para publicar.</key>
+        <key alias="yourRecentActivity">Tu actividad reciente</key>
+        <key alias="yourRecentActivitiesDescription">Muestra tu actividad reciente</key>
+        <key alias="publishedContentNodes">Nodos de contenido publicados</key>
+        <key alias="nodesInRecycleBin">Nodos en la papelera</key>
+        <key alias="membersOnWebsite">Miembros en la web</key>
+        <key alias="newMembersLastWeek">Nuevos miembros la semana pasada</key>
+        <key alias="butNotPublishedOrScheduled">pero no publicado o programado</key>
+        <key alias="butDidNotPublish">pero no publicado</key>
+        <key alias="forPublishingAt">que se publicará el</key>
+        <key alias="to">a</key>
+        <key alias="saved">guardó</key>
+        <key alias="moved">movió</key>
+        <key alias="unpublished">Despublicó</key>
+        <key alias="savedBy">guardado por</key>
+        <key alias="savedAndScheduled">guardó y programó</key>
+        <key alias="savedAndPublished">guardó y publicó</key>
+        <key alias="recycleBin">papelera</key>
+        <key alias="Saved">Guardado</key>
+        <key alias="Moved">Movido</key>
+        <key alias="Unpublished">No publicado</key>
+        <key alias="SavedAndScheduled">Guardado y programado</key>
+        <key alias="SavedAndPublished">Guardado y publicado</key>
+    </area>
+</language>

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/TheDashboard.css
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/TheDashboard.css
@@ -7,7 +7,7 @@ div.logitem {
 
 div.logitem img {
     -ms-border-radius: 20px;
-    border-radius: 30px;
+    border-radius: 50%;
     box-shadow: 3px 5px 7px -2px #555;
     width: 55px;
     height: 55px;
@@ -16,7 +16,8 @@ div.logitem img {
     margin-bottom: 20px;
 }
 
-div.logitem span { font-size: 12px;font-style: italic;}
+div.logitem span { font-size: 12px; font-style: italic; }
+div.logitem.has-avatar p { padding-left: 70px; }
 
 div.number {
     margin-bottom: 10px;

--- a/TheDashboard/Web/UI/App_Plugins/TheDashboard/TheDashboard.html
+++ b/TheDashboard/Web/UI/App_Plugins/TheDashboard/TheDashboard.html
@@ -1,65 +1,65 @@
 ﻿<div class="row" ng-controller="TheDashboard.Controller">
 
 	<div class="span3">
-		<h3>Recent activites</h3>
-		<p>Shows recent activites from all users in the back office.</p>
-		<div ng-repeat="item in vm.activities" class="logitem">
-			<img src="{{item.userAvatarUrl}}" />
-			<span>{{item.timestamp | date:'medium'}}</span>
-			<div>
-				<p ng-show="item.logItemType =='Save'">
-					<strong>{{item.userDisplayName}}</strong> saved <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> but did not publish.
-				</p>
-				<p ng-show="item.logItemType =='SavedAndScheduled'">
-					<strong>{{item.userDisplayName}}</strong> saved and scheduled <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> for publishing at {{item.scheduledPublishDate | date}}.
-				</p>
-				<p ng-show="item.logItemType =='Publish'">
-					<strong>{{item.userDisplayName}}</strong> saved and published <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
-				</p>
-				<p ng-show="item.logItemType =='Delete'">
-					<strong>{{item.userDisplayName}}</strong> moved {{item.nodeName}} to <a href="/umbraco/#/content/content/recyclebin">recycle bin.</a>
-				</p>
-				<p ng-show="item.logItemType =='UnPublish'">
-					<strong>{{item.userDisplayName}}</strong> unpublished {{item.nodeName}}.
-				</p>
-				<p ng-show="item.logItemType =='UnPublishToRecycleBin'">
-					<strong>{{item.userDisplayName}}</strong> moved {{item.nodeName}} to <a href="/umbraco/#/content/content/recyclebin">recycle bin</a>.
-				</p>
-			</div>
-		</div>
+		<h3><localize key="theDashboard_recentActivities">Recent activities</localize></h3>
+		<p><localize key="theDashboard_recentActivitiesDescription">Shows recent activities from all users in the back office.</localize></p>
+        <div ng-repeat="item in vm.activities" class="logitem has-avatar">
+            <img src="{{item.userAvatarUrl}}" />
+            <span>{{item.timestamp | date:'medium'}}</span>
+            <div>
+                <p ng-show="item.logItemType =='Save'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_saved">saved</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> <localize key="theDashboard_butDidNotPublish">but did not publish</localize>.
+                </p>
+                <p ng-show="item.logItemType =='SavedAndScheduled'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_savedAndScheduled">saved and scheduled</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> <localize key="theDashboard_forPublishingAt">for publishing at</localize> {{item.scheduledPublishDate | date}}.
+                </p>
+                <p ng-show="item.logItemType =='Publish'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_savedAndPublished">saved and published</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
+                </p>
+                <p ng-show="item.logItemType =='Delete'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_moved">moved</localize> {{item.nodeName}} <localize key="theDashboard_to">to</localize> <a href="/umbraco/#/content/content/recyclebin"><localize key="theDashboard_recycleBin">recycle bin</localize>.</a>
+                </p>
+                <p ng-show="item.logItemType =='UnPublish'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_unpublished">unpublished</localize> {{item.nodeName}}.
+                </p>
+                <p ng-show="item.logItemType =='UnPublishToRecycleBin'">
+                    <strong>{{item.userDisplayName}}</strong> <localize key="theDashboard_moved">moved</localize> {{item.nodeName}} <localize key="theDashboard_to">to</localize> <a href="/umbraco/#/content/content/recyclebin">recycle bin</a>.
+                </p>
+            </div>
+        </div>
 	</div>
 	<div class="span3 offset1">
 		<div ng-show="vm.unpublishedContent.length > 0">
-			<h3>Unpublished content</h3>
-			<p>Shows unpublished content that has not been been scheduled for publish.</p>
+			<h3><localize key="theDashboard_unpublishedContent">Unpublished content</localize></h3>
+			<p><localize key="theDashboard_unpublishedContentDescription">Shows unpublished content that has not been been scheduled for publish.</localize></p>
 			<div ng-repeat="item in vm.unpublishedContent" class="logitem">
 				<img src="{{item.userAvatarUrl}}" />
 				<span>{{item.timestamp | date:'medium'}}</span>
-				<p><a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> saved by {{item.userDisplayName}} but not published or scheduled.</p>
+				<p><a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> <localize key="theDashboard_savedBy">saved by</localize> {{item.userDisplayName}} <localize key="theDashboard_butNotPublishedOrScheduled">but not published or scheduled</localize>.</p>
 			</div>
 		</div>
 		<div>
-			<h3>Your recent activity</h3>
-			<p>Shows your own recent activities.</p>
+			<h3><localize key="theDashboard_yourRecentActivity">Your recent activity</localize></h3>
+			<p><localize key="theDashboard_yourRecentActivitiesDescription">Shows your own recent activities.</localize></p>
 			<div ng-repeat="item in vm.userRecentActivity" class="logitem">
 				<span>{{item.timestamp | date:'medium'}}</span>
 				<p ng-show="item.logItemType =='Save'">
-					Saved <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> but did not publish.
+                    <localize key="theDashboard_Saved">Saved</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> <localize key="theDashboard_butDidNotPublish">but did not publish</localize>.
 				</p>
 				<p ng-show="item.logItemType =='SavedAndScheduled'">
-					Saved and scheduled <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> for publishing at {{item.scheduledPublishDate | date}}.
+                    <localize key="theDashboard_SavedAndScheduled">Saved and scheduled</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a> <localize key="theDashboard_forPublishingAt">for publishing at</localize> {{item.scheduledPublishDate | date}}.
 				</p>
 				<p ng-show="item.logItemType =='Publish'">
-					Saved and published <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
+                    <localize key="theDashboard_SavedAndPublished">Saved and published</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
 				</p>
 				<p ng-show="item.logItemType =='Delete'">
-					Moved {{item.nodeName}} to <a href="/umbraco/#/content/content/recyclebin">recycle bin.</a>
+                    <localize key="theDashboard_Moved">Moved</localize> {{item.nodeName}} <localize key="theDashboard_to">to</localize> <a href="/umbraco/#/content/content/recyclebin">recycle bin.</a>
 				</p>
 				<p ng-show="item.logItemType =='UnPublish'">
-					Unpublished <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
+                    <localize key="theDashboard_Unpublished">Unpublished</localize> <a href="/umbraco/#/content/content/edit/{{item.nodeId}}">{{item.nodeName}}</a>.
 				</p>
 				<p ng-show="item.logItemType =='UnPublishToRecycleBin'">
-					Moved {{item.nodeName}} to <a href="/umbraco/#/content/content/recyclebin">recycle bin</a>.
+                    <localize key="theDashboard_Moved">Moved</localize> {{item.nodeName}} <localize key="theDashboard_to">to</localize> <a href="/umbraco/#/content/content/recyclebin"><localize key="theDashboard_recycleBin">recycle bin</localize></a>.
 				</p>
 			</div>
 		</div>
@@ -69,20 +69,20 @@
 		<h3></h3>
 		<div class="number">
 			<div class="dot">{{vm.countPublishedNodes}}</div>
-			<p>Published content nodes</p>
+			<p><localize key="theDashboard_publishedContentNodes">Published content nodes</localize></p>
 		</div>
 
 		<div class="number">
 			<div class="dot">{{vm.countContentInRecycleBin}}</div>
-			<p>Nodes in recyle bin</p>
+			<p><localize key="theDashboard_nodesInRecycleBin">Nodes in recyle bin</localize></p>
 		</div>
 		<div class="number">
 			<div class="dot members">{{vm.countTotalWebsiteMembers}}</div>
-			<p>Members on website</p>
+			<p><localize key="theDashboard_membersOnWebsite">Members on website</localize></p>
 		</div>
 		<div class="number">
 			<div class="dot members">{{vm.countNewMembersLastWeek}}</div>
-			<p>New members last week</p>
+			<p><localize key="theDashboard_newMembersLastWeek">New members last week</localize></p>
 		</div>
 		<!-- <div class="umbracoguy">
             <button class="btn btn-info" ng-click="magic = 'true'" ng-hide="magic=='true'">Magic button</button>


### PR DESCRIPTION
Issue #2 

Text in content dashboard is localized for da-DK, en-GB and en-US.

The /Lang folder can be included in the plugin folder and it will work in Umbraco 7.3.0
For earlier Umbraco 7 version people has to merge those keys into the core language files.
