### PR TITLE
Added check for null exception on checking namespace for reflected types

### DIFF
--- a/TheDashboard/Data/UmbracoRepository.cs
+++ b/TheDashboard/Data/UmbracoRepository.cs
@@ -136,7 +136,9 @@ namespace TheDashboard.Data
         {
             return AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(s => s.GetTypes())
-                .Where(p => baseType.IsAssignableFrom(p) && p.IsClass && !p.IsAbstract && !p.Namespace.ToLower().StartsWith("umbraco."));
+                .Where(p => baseType.IsAssignableFrom(p) && 
+                    p.IsClass && !p.IsAbstract && 
+                    (string.IsNullOrEmpty(p.Namespace) || !p.Namespace.ToLower().StartsWith("umbraco.")));
         }
 
         private static IEnumerable<string> GetActionMethodsOnController(Type controllerType, bool onlyGetMethods)


### PR DESCRIPTION
Not something I've replicated yet but having [reviewed on MSDN](https://msdn.microsoft.com/en-us/library/system.type.namespace.aspx) can see there can be instances where the namespace is null at the point where the error in issue #13 is being triggered.  So I think this update should account for that.  

Let me know how it goes though and can look into further if need be.