### PR TITLE
Fix for issue 11

### DIFF
--- a/TheDashboard/Core/Extensions/AssemblyExtensions.cs
+++ b/TheDashboard/Core/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Umbraco.Core;
+
+namespace TheDashboard.Core.Extensions
+{
+    /// <summary>
+    /// Provides extension methods to Assembly
+    /// </summary>
+    public static class AssemblyExtensions
+    {
+        /// <summary>
+        /// Safely loads types from a given assembly avoiding errors if certain ones can't be loaded
+        /// </summary>
+        /// <param name="assembly">Instance of an Assembly</param>
+        /// <returns>Enumerable of loadable types</returns>
+        /// <remarks>
+        /// For further on this and why needed, see: http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/
+        /// </remarks>
+        public static IEnumerable<Type> GetLoadableTypes(this Assembly assembly)
+        {
+            Mandate.ParameterNotNull(assembly, "assembly");
+
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException e)
+            {
+                return e.Types.Where(t => t != null);
+            }
+        }
+    }
+}

--- a/TheDashboard/Data/UmbracoRepository.cs
+++ b/TheDashboard/Data/UmbracoRepository.cs
@@ -13,6 +13,8 @@ using Umbraco.Web.Routing;
 
 namespace TheDashboard.Data
 {
+    using TheDashboard.Core.Extensions;
+
     public class UmbracoRepository
     {
         #region Content dashboard
@@ -135,7 +137,7 @@ namespace TheDashboard.Data
         private IEnumerable<Type> GetNonCoreTypesAssignableFrom(Type baseType)
         {
             return AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(s => s.GetTypes())
+                .SelectMany(s => s.GetLoadableTypes())
                 .Where(p => baseType.IsAssignableFrom(p) && 
                     p.IsClass && !p.IsAbstract && 
                     (string.IsNullOrEmpty(p.Namespace) || !p.Namespace.ToLower().StartsWith("umbraco.")));

--- a/TheDashboard/TheDashboard.csproj
+++ b/TheDashboard/TheDashboard.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Api\Attributes\CamelCaseController.cs" />
     <Compile Include="Api\TheDevDasboardController.cs" />
     <Compile Include="Api\TheDasboardController.cs" />
+    <Compile Include="Core\Extensions\AssemblyExtensions.cs" />
     <Compile Include="Core\Extensions\DateExtensions.cs" />
     <Compile Include="Core\GravatarHelper.cs" />
     <Compile Include="Core\UserAvatarProvider.cs" />


### PR DESCRIPTION
This works by ensuring all types scanned when accessing types from assemblies can be loaded.  As noted on the issue I've come across this problem with another package and Umbraco 7.4+ and believe the issue is the the one described (and solution provided) [here](http://haacked.com/archive/2012/07/23/get-all-types-in-an-assembly.aspx/).