### PR TITLE
Support variant save, publish and unpublish log headers

### DIFF
--- a/Our.Umbraco.TheDashboard/Mapping/LogEntryToRecentActivityMapper.cs
+++ b/Our.Umbraco.TheDashboard/Mapping/LogEntryToRecentActivityMapper.cs
@@ -1,70 +1,80 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Our.Umbraco.TheDashboard.Extensions;
+﻿using Our.Umbraco.TheDashboard.Extensions;
 using Our.Umbraco.TheDashboard.Models.Dtos;
 using Our.Umbraco.TheDashboard.Models.Frontend;
 using Umbraco.Core.Cache;
 
 namespace Our.Umbraco.TheDashboard.Mapping
 {
-    public class LogEntryToRecentActivityMapper
-    {
-        private readonly AppCaches _appCaches;
+	public class LogEntryToRecentActivityMapper
+	{
+		private readonly AppCaches _appCaches;
 
-        public LogEntryToRecentActivityMapper(AppCaches appCaches)
-        {
-            _appCaches = appCaches;
-        }
+		public LogEntryToRecentActivityMapper(AppCaches appCaches)
+		{
+			_appCaches = appCaches;
+		}
 
-        public RecentActivityFrontendModel Map(LogEntryDto dto)
-        {
-            var dashboardLogEntryType = GetLogEntryType(dto);
+		public RecentActivityFrontendModel Map(LogEntryDto dto)
+		{
+			var dashboardLogEntryType = GetLogEntryType(dto);
 
-            if (string.IsNullOrEmpty(dashboardLogEntryType))
-                return null;
+			if (string.IsNullOrEmpty(dashboardLogEntryType))
+			{
+				return null;
+			}
 
-            return new RecentActivityFrontendModel()
-            {
-                NodeId = dto.NodeId,
-                NodeName = dto.NodeName,
-                Datestamp = dto.Datestamp,
-                ScheduledPublishDate = dto.NodeScheduledDate,
-                ActivityType = dashboardLogEntryType,
-                User = new UserFrontendModel() {
-                    Name = dto.UserName,
-                    Avatar = UserExtensions.GetUserAvatarUrls(dto.UserId,dto.UserEmail,dto.UserAvatar, _appCaches.RuntimeCache)
-                }
-            };
+			return new RecentActivityFrontendModel()
+			{
+				NodeId = dto.NodeId,
+				NodeName = dto.NodeName,
+				Datestamp = dto.Datestamp,
+				ScheduledPublishDate = dto.NodeScheduledDate,
+				ActivityType = dashboardLogEntryType,
+				User = new UserFrontendModel()
+				{
+					Name = dto.UserName,
+					Avatar = UserExtensions.GetUserAvatarUrls(dto.UserId, dto.UserEmail, dto.UserAvatar, _appCaches.RuntimeCache)
+				}
+			};
+		}
 
-        }
+		private string GetLogEntryType(LogEntryDto dto)
+		{
+			if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Publish ||
+				dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.PublishVariant)
+			{
+				return TheDashboardConstants.ActivityTypes.Publish;
+			}
 
-        private string GetLogEntryType(LogEntryDto dto)
-        {
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Publish)
-                return TheDashboardConstants.ActivityTypes.Publish;
+			if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Save ||
+				dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.SaveVariant)
+			{
+				if (dto.NodeScheduledDate.HasValue)
+				{
+					return TheDashboardConstants.ActivityTypes.SaveAndScheduled;
+				}
 
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Save && dto.NodeScheduledDate.HasValue)
-                return TheDashboardConstants.ActivityTypes.SaveAndScheduled;
+				return TheDashboardConstants.ActivityTypes.Save;
+			}
 
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Save)
-                return TheDashboardConstants.ActivityTypes.Save;
+			if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Unpublish ||
+				dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.UnpublishVariant)
+			{
+				return TheDashboardConstants.ActivityTypes.Unpublish;
+			}
 
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Unpublish)
-                return TheDashboardConstants.ActivityTypes.Unpublish;
+			if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.RollBack)
+			{
+				return TheDashboardConstants.ActivityTypes.RollBack;
+			}
 
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.RollBack)
-                return TheDashboardConstants.ActivityTypes.RollBack;
+			if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Delete && dto.LogComment.Contains("Trashed"))
+			{
+				return TheDashboardConstants.ActivityTypes.RecycleBin;
+			}
 
-            if (dto.LogHeader == TheDashboardConstants.UmbracoLogHeaders.Delete && dto.LogComment.Contains("Trashed"))
-                return TheDashboardConstants.ActivityTypes.RecycleBin;
-
-            // Empty string means this is a type of LogEntryDto that we don't care about.
-            return string.Empty;
-
-        }
-
-    }
+			// Empty string means this is a type of LogEntryDto that we don't care about.
+			return string.Empty;
+		}
+	}
 }

--- a/Our.Umbraco.TheDashboard/Services/TheDashboardService.cs
+++ b/Our.Umbraco.TheDashboard/Services/TheDashboardService.cs
@@ -85,7 +85,7 @@ namespace Our.Umbraco.TheDashboard.Services
 	            AND ud.edited = 1 
 	            AND ud.published = 1 
 	            AND ucs.[action] is null
-	            AND ul.logHeader = 'Save'
+	            AND (ul.logHeader = 'Save' OR ul.logHeader = 'SaveVariant')
 
               ORDER by ul.Datestamp DESC
             ";

--- a/Our.Umbraco.TheDashboard/TheDashboardConstants.cs
+++ b/Our.Umbraco.TheDashboard/TheDashboardConstants.cs
@@ -1,37 +1,32 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Umbraco.Core.Models;
 
 namespace Our.Umbraco.TheDashboard
 {
-    public static class TheDashboardConstants
-    {
-        public static class ActivityTypes
-        {
-            public const string Publish = "Publish";
-            public const string Save = "Save";
-            public const string SaveAndScheduled = "SaveAndScheduled";
-            public const string RollBack = "RollBack";
-            public const string RecycleBin = "RecycleBin";
-            public const string Unpublish = "Unpublish";
-        }
+	public static class TheDashboardConstants
+	{
+		public static class ActivityTypes
+		{
+			public const string Publish = "Publish";
+			public const string Save = "Save";
+			public const string SaveAndScheduled = "SaveAndScheduled";
+			public const string RollBack = "RollBack";
+			public const string RecycleBin = "RecycleBin";
+			public const string Unpublish = "Unpublish";
+		}
 
-        public static class UmbracoLogHeaders
-        {
-            public const string Publish = "Publish";
-            public const string Save = "Save";
-            
-            public const string RollBack = "RollBack";
-            public const string Move = "Move";
-            public const string Delete = "Delete";
-            public const string Unpublish = "Unpublish";
-
-
-            public const string Copy = "Copy";
-            public const string Sort = "Sort";
-        }
-        
-    }
+		public static class UmbracoLogHeaders
+		{
+			public const string Publish = nameof(AuditType.Publish);
+			public const string PublishVariant = nameof(AuditType.PublishVariant);
+			public const string Save = nameof(AuditType.Save);
+			public const string SaveVariant = nameof(AuditType.SaveVariant);
+			public const string RollBack = nameof(AuditType.RollBack);
+			public const string Move = nameof(AuditType.Move);
+			public const string Delete = nameof(AuditType.Delete);
+			public const string Unpublish = nameof(AuditType.Unpublish);
+			public const string UnpublishVariant = nameof(AuditType.UnpublishVariant);
+			public const string Copy = nameof(AuditType.Copy);
+			public const string Sort = nameof(AuditType.Sort);
+		}
+	}
 }


### PR DESCRIPTION
This fixes https://github.com/enkelmedia/TheDashboard/issues/48 by making sure the dashboard also shows recent activity for saving, publishing and unpublishing culture variant content.

It however doesn't show in which language this action is done, as that's only available as comma seperated language names in the `umbracoLog.parameters` column. That means it's not possible to add a `mculture`/`cculture` parameter to the edit links (the culture code isn't available and a single log is written if multiple languages are saved/published/unpublished in a single action). The `TheDashboardController.CreateFrontendModelsFrom` method also only returns a single model per node ID, so that would only return the last action and not one per language.

The `NodeScheduledDate` also doesn't account for the fact it can contain multiple rows per node in the `umbracoContentSchedule` table (one for every language). It also doesn't check whether the scheduled action is set to `ContentScheduleAction.Release`, so this is already the case if both a publish and unpublish date are set, but that's a different issue.