### PR TITLE
Fix casing of App_Plugins

### DIFF
--- a/Our.Umbraco.TheDashboard/App_Plugins/Our.Umbraco.TheDashboard/package.manifest
+++ b/Our.Umbraco.TheDashboard/App_Plugins/Our.Umbraco.TheDashboard/package.manifest
@@ -1,9 +1,9 @@
 ﻿{
-    "javascript" : [
-        "/app_plugins/Our.Umbraco.TheDashboard/TheDashboard.controller.js"
-    ],
+  "javascript": [
+    "~/App_Plugins/Our.Umbraco.TheDashboard/TheDashboard.controller.js"
+  ],
   "css": [
-      "/app_plugins/Our.Umbraco.TheDashboard/TheDashboard.css"
+    "~/App_Plugins/Our.Umbraco.TheDashboard/TheDashboard.css"
   ]
 
 }


### PR DESCRIPTION
Fix #64 

Reason: In the method [AddRuntimeMinifier](https://github.com/umbraco/Umbraco-CMS/blob/5bfab13dc5a268714aad2426a2b68ab5561a6407/src/Umbraco.Web.Common/DependencyInjection/UmbracoBuilderExtensions.cs#L274):
```csharp
                return new SmidgeFileProvider(
                    hostEnv.WebRootFileProvider,
                    new GlobPatternFilterFileProvider(
                        hostEnv.ContentRootFileProvider,
                        // only include js or css files within App_Plugins
                        new[] { "/App_Plugins/**/*.js", "/App_Plugins/**/*.css" }));
```
The Glob Pattern uses /App_plugins/ and globs are case sensitive, which mean your files are filtered out.

To reproduce the error, you only have to change your appsettings : 
```json
{
"Umbraco": {
      "Hosting": {
        "Debug": false
      }
  }
}
```

Based on https://github.com/KevinJump/uSync/blob/v9/main/uSync.Backoffice.Assets/App_Plugins/uSync/package.manifest
where All paths starts with:~/App_Plugins/

