### PR TITLE
[IMPLEMENT] Upgrade to Umbraco v10 7

### DIFF
--- a/Our.Umbraco.TheDashboard.Testsite/Our.Umbraco.TheDashboard.Testsite.csproj
+++ b/Our.Umbraco.TheDashboard.Testsite/Our.Umbraco.TheDashboard.Testsite.csproj
@@ -1,12 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms" Version="9.0.0" />
-        <PackageReference Include="Umbraco.Cms.SqlCe" Version="9.0.0" />
-        <PackageReference Include="Umbraco.SqlServerCE" Version="4.0.0.1" />
+        <PackageReference Include="Umbraco.Cms" Version="10.0.0" />
     </ItemGroup>
 
     <Import Project="..\Our.Umbraco.TheDashboard\build\Our.Umbraco.TheDashboard.targets"/>

--- a/Our.Umbraco.TheDashboard.Testsite/Program.cs
+++ b/Our.Umbraco.TheDashboard.Testsite/Program.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 

--- a/Our.Umbraco.TheDashboard.Testsite/Startup.cs
+++ b/Our.Umbraco.TheDashboard.Testsite/Startup.cs
@@ -4,8 +4,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Umbraco.Cms.Core.DependencyInjection;
-using Umbraco.Extensions;
 
 namespace Our.Umbraco.TheDashboard.Testsite
 {

--- a/Our.Umbraco.TheDashboard/Controllers/TheDasboardController.cs
+++ b/Our.Umbraco.TheDashboard/Controllers/TheDasboardController.cs
@@ -8,7 +8,7 @@ using Our.Umbraco.TheDashboard.Models.Frontend;
 using Our.Umbraco.TheDashboard.Security;
 using Our.Umbraco.TheDashboard.Services;
 using Umbraco.Cms.Core.Cache;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Security;
 using Umbraco.Cms.Core.Services;
 using Umbraco.Cms.Web.BackOffice.Controllers;

--- a/Our.Umbraco.TheDashboard/Counters/IDashboardCounter.cs
+++ b/Our.Umbraco.TheDashboard/Counters/IDashboardCounter.cs
@@ -1,4 +1,4 @@
-﻿using Umbraco.Cms.Core.Scoping;
+﻿using Umbraco.Cms.Infrastructure.Scoping;
 
 namespace Our.Umbraco.TheDashboard.Counters
 {

--- a/Our.Umbraco.TheDashboard/Counters/Implement/ContentInRecycleBinDashboardCounter.cs
+++ b/Our.Umbraco.TheDashboard/Counters/Implement/ContentInRecycleBinDashboardCounter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 
 namespace Our.Umbraco.TheDashboard.Counters.Implement
@@ -20,8 +20,8 @@ namespace Our.Umbraco.TheDashboard.Counters.Implement
                                WHERE un.nodeObjectType = @0 	
 	                           AND un.trashed = 1";
 
-            var count = scope.Database.ExecuteScalar<int>(sql, Constants.ObjectTypes.Document.ToString());
-
+            var count = scope.Database.ExecuteScalar<int>(sql, Constants.ObjectTypes.Document);
+            
             return new DashboardCounterModel()
             {
                 Text = _localizedTextService.Localize("theDashboard","nodesInRecycleBin",Thread.CurrentThread.CurrentCulture),

--- a/Our.Umbraco.TheDashboard/Counters/Implement/ContentTotalContentItemsDashboardCounter.cs
+++ b/Our.Umbraco.TheDashboard/Counters/Implement/ContentTotalContentItemsDashboardCounter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading;
 using Umbraco.Cms.Core;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 
 namespace Our.Umbraco.TheDashboard.Counters.Implement
@@ -25,7 +25,7 @@ namespace Our.Umbraco.TheDashboard.Counters.Implement
                         AND un.trashed = 0
 	                    AND ud.published = 1";
 
-            var count = scope.Database.ExecuteScalar<int>(sql, Constants.ObjectTypes.Document.ToString());
+            var count = scope.Database.ExecuteScalar<int>(sql, Constants.ObjectTypes.Document);
 
             return new DashboardCounterModel()
             {

--- a/Our.Umbraco.TheDashboard/Counters/Implement/MembersNewLastWeekDashboardCounter.cs
+++ b/Our.Umbraco.TheDashboard/Counters/Implement/MembersNewLastWeekDashboardCounter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Threading;
-using Umbraco.Cms.Core.Scoping;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 
 namespace Our.Umbraco.TheDashboard.Counters.Implement

--- a/Our.Umbraco.TheDashboard/Counters/Implement/MembersTotalDashboardCounter.cs
+++ b/Our.Umbraco.TheDashboard/Counters/Implement/MembersTotalDashboardCounter.cs
@@ -1,7 +1,5 @@
-﻿
-
-using System.Threading;
-using Umbraco.Cms.Core.Scoping;
+﻿using System.Threading;
+using Umbraco.Cms.Infrastructure.Scoping;
 using Umbraco.Cms.Core.Services;
 
 namespace Our.Umbraco.TheDashboard.Counters.Implement

--- a/Our.Umbraco.TheDashboard/Models/Dtos/LogEntryDto.cs
+++ b/Our.Umbraco.TheDashboard/Models/Dtos/LogEntryDto.cs
@@ -22,16 +22,4 @@ namespace Our.Umbraco.TheDashboard.Models.Dtos
         public string UserAvatar { get; set; }
 
     }
-
-    public class UmbracoNodeDTO
-    {
-        [Column("id")]
-        public int Id {get;set;}
-
-        [Column("nodeObjectType")]
-        public string ObjectType { get; internal set; }
-
-        [Column("trashed")]
-        public bool Trashed { get; internal set; }
-    }
 }

--- a/Our.Umbraco.TheDashboard/Models/Dtos/LogEntryDto.cs
+++ b/Our.Umbraco.TheDashboard/Models/Dtos/LogEntryDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using NPoco;
 
 namespace Our.Umbraco.TheDashboard.Models.Dtos
 {
@@ -20,5 +21,17 @@ namespace Our.Umbraco.TheDashboard.Models.Dtos
         public string UserEmail { get; set; }
         public string UserAvatar { get; set; }
 
+    }
+
+    public class UmbracoNodeDTO
+    {
+        [Column("id")]
+        public int Id {get;set;}
+
+        [Column("nodeObjectType")]
+        public string ObjectType { get; internal set; }
+
+        [Column("trashed")]
+        public bool Trashed { get; internal set; }
     }
 }

--- a/Our.Umbraco.TheDashboard/Our.Umbraco.TheDashboard.csproj
+++ b/Our.Umbraco.TheDashboard/Our.Umbraco.TheDashboard.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <ContentTargetFolders>.</ContentTargetFolders>
         <PackageId>Our.Umbraco.TheDashboard</PackageId>
         <Title>Our.Umbraco.TheDashboard</Title>
-        <Description>Content dashboard for Umbraco 9</Description>
+        <Description>Content dashboard for Umbraco 10</Description>
         <Product>The Dashboard for Umbraco</Product>
         <PackageTags>umbraco plugin package</PackageTags>
-        <Version>9.0.0</Version>
+        <Version>10.0.0</Version>
         <Authors>Markus Johansson</Authors>
         <Copyright>Copyright (c) Obviuse AB</Copyright>
         <Company>Obviuse AB / Enkel Media Stockholm AB</Company>
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Umbraco.Cms.Web.Website" Version="9.0.0" />
-        <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="9.0.0" />
+        <PackageReference Include="Umbraco.Cms.Web.Website" Version="10.0.0" />
+        <PackageReference Include="Umbraco.Cms.Web.BackOffice" Version="10.0.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
 - [IMPLEMENT] Update to Net6
 - [AMEND] Replace use of WebRequest with HTTPClient
 - [IMPLEMENT] SQLite Support for Umbraco v10

Notes: 

* SQLite support required a messy amend as SQLite doesn't support `Select Top()` so you have to use `Limit`, but SQL doesn't support limit.
* Removal of `.ToString()` when passing in the Object Type as SQLite doesn't work with it, but SQL and SQLite both work without.