### PR TITLE
Adjust DateTimeOptions to output in dates in more consistent format

### DIFF
--- a/src/Our.Umbraco.TheDashboard/Client/src/dashboard/the-dashboard.element.ts
+++ b/src/Our.Umbraco.TheDashboard/Client/src/dashboard/the-dashboard.element.ts
@@ -8,11 +8,11 @@ import './../components/box/the-dashboard-box.element';
 const DateTimeOptions: Intl.DateTimeFormatOptions = {
   weekday: 'short',
   year: 'numeric',
-  month: 'numeric',
+  month: 'long',
   day: 'numeric',
-  hour : '2-digit',
-  minute : '2-digit',
-  hourCycle : 'h23'
+  hour: 'numeric',
+  minute: '2-digit',
+  hour12: true
 };
 
 /**


### PR DESCRIPTION
Fix for #118 

Update to file 'the-dashboard.element.ts' where DateTimeOptions adjusted
- month to use 'long' format, e.g. April
- time to output in 12hr AM/PM format (no seconds), e.g. 1:23 PM